### PR TITLE
remove node 11 from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
   - "12"
-  - "11"
   - "10"
   - "8"


### PR DESCRIPTION
nodejs v12 is LTS now and v11 has served its life